### PR TITLE
Refactor training sheet and exercise archiving

### DIFF
--- a/GestaoEquipas.Business/GestaoEquipas.Business.csproj
+++ b/GestaoEquipas.Business/GestaoEquipas.Business.csproj
@@ -4,5 +4,6 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\GestaoEquipas.Data\GestaoEquipas.Data.csproj" />
+    <PackageReference Include="PdfSharpNetStandard" Version="1.3.6" />
   </ItemGroup>
 </Project>

--- a/GestaoEquipas.Business/Services/ExerciseService.cs
+++ b/GestaoEquipas.Business/Services/ExerciseService.cs
@@ -1,0 +1,19 @@
+using GestaoEquipas.Data.DataAccess;
+using GestaoEquipas.Data.Models;
+using System.Collections.Generic;
+
+namespace GestaoEquipas.Business.Services
+{
+    public class ExerciseService
+    {
+        private readonly ExerciseRepository _repo = new ExerciseRepository();
+
+        public int AddExercise(Exercise exercise) => _repo.Add(exercise);
+
+        public IEnumerable<Exercise> GetExercises(bool includeArchived = false) => _repo.GetAll(includeArchived);
+
+        public void ArchiveExercise(int id) => _repo.UpdateArchiveStatus(id, true);
+
+        public void UnarchiveExercise(int id) => _repo.UpdateArchiveStatus(id, false);
+    }
+}

--- a/GestaoEquipas.Business/Services/TrainingSheetService.cs
+++ b/GestaoEquipas.Business/Services/TrainingSheetService.cs
@@ -1,0 +1,31 @@
+using GestaoEquipas.Data.Models;
+using PdfSharp.Drawing;
+using PdfSharp.Pdf;
+
+namespace GestaoEquipas.Business.Services
+{
+    public class TrainingSheetService
+    {
+        public void ExportToPdf(TrainingSheet sheet, string filePath)
+        {
+            var doc = new PdfDocument();
+            var page = doc.AddPage();
+            var gfx = XGraphics.FromPdfPage(page);
+            var fontTitle = new XFont("Verdana", 20, XFontStyle.Bold);
+            var font = new XFont("Verdana", 12);
+
+            int y = 40;
+            gfx.DrawString($"Treino: {sheet.Date:yyyy-MM-dd}", fontTitle, XBrushes.Black, new XPoint(40, y));
+            y += 30;
+            gfx.DrawString(sheet.Notes, font, XBrushes.Black, new XPoint(40, y));
+            y += 30;
+            foreach (var ex in sheet.Exercises)
+            {
+                gfx.DrawString($"- {ex.Name}: {ex.Description}", font, XBrushes.Black, new XPoint(50, y));
+                y += 20;
+            }
+
+            doc.Save(filePath);
+        }
+    }
+}

--- a/GestaoEquipas.Data/DataAccess/Database.cs
+++ b/GestaoEquipas.Data/DataAccess/Database.cs
@@ -49,6 +49,12 @@ CREATE TABLE IF NOT EXISTS PerformanceStats(
     PlayerId INTEGER,
     Rating INTEGER
 );
+CREATE TABLE IF NOT EXISTS Exercises(
+    Id INTEGER PRIMARY KEY AUTOINCREMENT,
+    Name TEXT,
+    Description TEXT,
+    Archived INTEGER
+);
 ";
             cmd.ExecuteNonQuery();
         }

--- a/GestaoEquipas.Data/DataAccess/ExerciseRepository.cs
+++ b/GestaoEquipas.Data/DataAccess/ExerciseRepository.cs
@@ -1,0 +1,49 @@
+using GestaoEquipas.Data.Models;
+using System.Collections.Generic;
+
+namespace GestaoEquipas.Data.DataAccess
+{
+    public class ExerciseRepository
+    {
+        public int Add(Exercise exercise)
+        {
+            using var conn = Database.GetConnection();
+            var cmd = conn.CreateCommand();
+            cmd.CommandText = "INSERT INTO Exercises(Name, Description, Archived) VALUES(@n,@d,@a)";
+            cmd.Parameters.AddWithValue("@n", exercise.Name);
+            cmd.Parameters.AddWithValue("@d", exercise.Description);
+            cmd.Parameters.AddWithValue("@a", exercise.Archived ? 1 : 0);
+            cmd.ExecuteNonQuery();
+            cmd.CommandText = "SELECT last_insert_rowid()";
+            return (int)(long)cmd.ExecuteScalar();
+        }
+
+        public IEnumerable<Exercise> GetAll(bool includeArchived = false)
+        {
+            using var conn = Database.GetConnection();
+            var cmd = conn.CreateCommand();
+            cmd.CommandText = "SELECT Id, Name, Description, Archived FROM Exercises" + (includeArchived ? string.Empty : " WHERE Archived=0");
+            using var reader = cmd.ExecuteReader();
+            while (reader.Read())
+            {
+                yield return new Exercise
+                {
+                    Id = reader.GetInt32(0),
+                    Name = reader.GetString(1),
+                    Description = reader.GetString(2),
+                    Archived = reader.GetInt32(3) == 1
+                };
+            }
+        }
+
+        public void UpdateArchiveStatus(int id, bool archived)
+        {
+            using var conn = Database.GetConnection();
+            var cmd = conn.CreateCommand();
+            cmd.CommandText = "UPDATE Exercises SET Archived=@a WHERE Id=@id";
+            cmd.Parameters.AddWithValue("@a", archived ? 1 : 0);
+            cmd.Parameters.AddWithValue("@id", id);
+            cmd.ExecuteNonQuery();
+        }
+    }
+}

--- a/GestaoEquipas.Data/Models/Exercise.cs
+++ b/GestaoEquipas.Data/Models/Exercise.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace GestaoEquipas.Data.Models
+{
+    public class Exercise
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
+        public bool Archived { get; set; }
+    }
+}

--- a/GestaoEquipas.Data/Models/TrainingSheet.cs
+++ b/GestaoEquipas.Data/Models/TrainingSheet.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+
+namespace GestaoEquipas.Data.Models
+{
+    public class TrainingSheet
+    {
+        public DateTime Date { get; set; }
+        public string Notes { get; set; } = string.Empty;
+        public List<Exercise> Exercises { get; set; } = new();
+    }
+}

--- a/GestaoEquipas.UI/Views/TrainingsWindow.xaml
+++ b/GestaoEquipas.UI/Views/TrainingsWindow.xaml
@@ -1,7 +1,7 @@
 <Window x:Class="GestaoEquipas.UI.Views.TrainingsWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Treinos" Height="300" Width="400">
+        Title="Treinos" Height="450" Width="450">
     <DockPanel Margin="10">
         <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Margin="0 0 0 10">
             <DatePicker Name="DatePicker" Width="120" Margin="0 0 10 0"/>
@@ -14,6 +14,19 @@
                 <DataGridCheckBoxColumn Header="Presente" Binding="{Binding Present}"/>
             </DataGrid.Columns>
         </DataGrid>
-        <ListBox Name="SessionsList" />
+        <ListBox Name="SessionsList" Margin="0 0 0 10"/>
+        <TextBlock Text="Exercícios:" FontWeight="Bold" Margin="0 5 0 2"/>
+        <ListBox Name="ExercisesList" SelectionMode="Extended" Height="80" Margin="0 0 0 10"/>
+        <StackPanel Orientation="Horizontal" Margin="0 0 0 10">
+            <TextBox Name="ExerciseNameBox" Width="120" Margin="0 0 5 0" />
+            <TextBox Name="ExerciseDescBox" Width="150" Margin="0 0 5 0" />
+            <Button Content="Criar" Click="AddExercise_Click" />
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" Margin="0 0 0 10">
+            <Button Content="Arquivar" Margin="0 5 5 0" Click="ArchiveExercise_Click"/>
+            <Button Content="Repor" Margin="0 5 5 0" Click="UnarchiveExercise_Click"/>
+            <CheckBox Name="ShowArchivedBox" Content="Mostrar Arquivados" Checked="ShowArchived_Checked" Unchecked="ShowArchived_Checked"/>
+        </StackPanel>
+        <Button Content="Exportar PDF" Click="ExportPdf_Click" />
     </DockPanel>
 </Window>

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Este projeto é uma aplicação desktop desenvolvida em C# e WPF, inspirada no F
 ## Pré-requisitos
 
 - **Sistema Operacional:** Windows 10 ou superior
-- **.NET 6 SDK** com suporte a desktop/wpf
+- **.NET 6 SDK** (ou superior) com suporte a desktop/WPF
 - **IDE:** Microsoft Visual Studio 2022 (ou compatível)
 - **Base de Dados:** SQLite3
 
@@ -18,6 +18,7 @@ Este projeto é uma aplicação desktop desenvolvida em C# e WPF, inspirada no F
 2. **Abra o Projeto:**
    - Localize o arquivo `GestaoEquipas.sln` na raiz do repositório e abra-o no Visual Studio.
 3. **Compilar:**
+   - Execute `dotnet restore` para obter as dependências.
    - Selecione a configuração **Debug** e use `Build > Build Solution`.
 4. **Executar:**
    - Pressione **F5** para iniciar a aplicação. Na primeira execução o arquivo `gestao_equipas.db` será criado automaticamente.
@@ -32,6 +33,8 @@ Este projeto é uma aplicação desktop desenvolvida em C# e WPF, inspirada no F
 
 - **Gestão de Jogadores** – adicionar e listar jogadores.
 - **Gestão de Treinos** – criar sessões de treino.
+- **Gestão de Exercícios** – criar, arquivar e reutilizar exercícios.
+- **Folha de Treino** – compilar exercícios e exportar em PDF.
 - **Gestão de Jogos** – registar jogos e resultados.
 - **Editor Tático** – janela de demonstração para futuras funcionalidades.
 


### PR DESCRIPTION
## Summary
- add `TrainingSheetService` to handle PDF export
- move PdfSharp dependency to business layer
- extend trainings window with exercise archiving options
- show archived exercises and toggle them
- update README with build instructions

## Testing
- `dotnet build GestaoEquipas.sln` *(fails: package `PdfSharpNetStandard` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68704e4bf9e483299a985cd53faf0227