### PR TITLE
Add competitions, attendance UI, standings, exercise archiving and DB migration

### DIFF
--- a/GestaoEquipas.Business/Services/CompetitionService.cs
+++ b/GestaoEquipas.Business/Services/CompetitionService.cs
@@ -1,0 +1,15 @@
+using GestaoEquipas.Data.DataAccess;
+using GestaoEquipas.Data.Models;
+using System.Collections.Generic;
+
+namespace GestaoEquipas.Business.Services
+{
+    public class CompetitionService
+    {
+        private readonly CompetitionRepository _repo = new CompetitionRepository();
+
+        public int AddCompetition(Competition competition) => _repo.Add(competition);
+
+        public IEnumerable<Competition> GetCompetitions() => _repo.GetAll();
+    }
+}

--- a/GestaoEquipas.Business/Services/GameService.cs
+++ b/GestaoEquipas.Business/Services/GameService.cs
@@ -11,5 +11,7 @@ namespace GestaoEquipas.Business.Services
         public int AddGame(Game game) => _repo.Add(game);
 
         public IEnumerable<Game> GetGames() => _repo.GetAll();
+
+        public void DeleteGame(int gameId) => _repo.Delete(gameId);
     }
 }

--- a/GestaoEquipas.Data/DataAccess/CompetitionRepository.cs
+++ b/GestaoEquipas.Data/DataAccess/CompetitionRepository.cs
@@ -1,0 +1,39 @@
+using GestaoEquipas.Data.Models;
+using System.Collections.Generic;
+
+namespace GestaoEquipas.Data.DataAccess
+{
+    public class CompetitionRepository
+    {
+        public int Add(Competition competition)
+        {
+            using var conn = Database.GetConnection();
+            var cmd = conn.CreateCommand();
+            cmd.CommandText = "INSERT INTO Competitions(Name, Type, Season) VALUES(@name, @type, @season)";
+            cmd.Parameters.AddWithValue("@name", competition.Name);
+            cmd.Parameters.AddWithValue("@type", competition.Type);
+            cmd.Parameters.AddWithValue("@season", competition.Season);
+            cmd.ExecuteNonQuery();
+            cmd.CommandText = "SELECT last_insert_rowid()";
+            return (int)(long)cmd.ExecuteScalar();
+        }
+
+        public IEnumerable<Competition> GetAll()
+        {
+            using var conn = Database.GetConnection();
+            var cmd = conn.CreateCommand();
+            cmd.CommandText = "SELECT Id, Name, Type, Season FROM Competitions ORDER BY Season DESC, Name";
+            using var reader = cmd.ExecuteReader();
+            while (reader.Read())
+            {
+                yield return new Competition
+                {
+                    Id = reader.GetInt32(0),
+                    Name = reader.GetString(1),
+                    Type = reader.GetString(2),
+                    Season = reader.GetString(3)
+                };
+            }
+        }
+    }
+}

--- a/GestaoEquipas.Data/DataAccess/Database.cs
+++ b/GestaoEquipas.Data/DataAccess/Database.cs
@@ -6,7 +6,7 @@ namespace GestaoEquipas.Data.DataAccess
 {
     public static class Database
     {
-        private static readonly string DbPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "gestao_equipas.db");
+        private static readonly string DbPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "futmax.db");
 
         public static SqliteConnection GetConnection()
         {

--- a/GestaoEquipas.Data/DataAccess/Database.cs
+++ b/GestaoEquipas.Data/DataAccess/Database.cs
@@ -35,7 +35,14 @@ CREATE TABLE IF NOT EXISTS Games(
     Id INTEGER PRIMARY KEY AUTOINCREMENT,
     Date TEXT,
     Opponent TEXT,
+    Competition TEXT,
     Result TEXT
+);
+CREATE TABLE IF NOT EXISTS Competitions(
+    Id INTEGER PRIMARY KEY AUTOINCREMENT,
+    Name TEXT NOT NULL,
+    Type TEXT NOT NULL,
+    Season TEXT NOT NULL
 );
 CREATE TABLE IF NOT EXISTS AttendanceRecords(
     Id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -57,6 +64,26 @@ CREATE TABLE IF NOT EXISTS Exercises(
 );
 ";
             cmd.ExecuteNonQuery();
+
+            var migration = conn.CreateCommand();
+            migration.CommandText = "ALTER TABLE Games ADD COLUMN Competition TEXT DEFAULT 'Liga'";
+            try
+            {
+                migration.ExecuteNonQuery();
+            }
+            catch (SqliteException)
+            {
+                // coluna já existe
+            }
+
+            var seed = conn.CreateCommand();
+            seed.CommandText = @"
+INSERT INTO Competitions(Name, Type, Season)
+SELECT 'Liga', 'Liga', '2025/2026' WHERE NOT EXISTS (SELECT 1 FROM Competitions);
+INSERT INTO Competitions(Name, Type, Season)
+SELECT 'Taça', 'Taça', '2025/2026' WHERE NOT EXISTS (SELECT 1 FROM Competitions WHERE Name='Taça' AND Season='2025/2026');
+";
+            seed.ExecuteNonQuery();
         }
     }
 }

--- a/GestaoEquipas.Data/DataAccess/GameRepository.cs
+++ b/GestaoEquipas.Data/DataAccess/GameRepository.cs
@@ -9,9 +9,10 @@ namespace GestaoEquipas.Data.DataAccess
         {
             using var conn = Database.GetConnection();
             var cmd = conn.CreateCommand();
-            cmd.CommandText = "INSERT INTO Games(Date, Opponent, Result) VALUES(@date, @opp, @res)";
+            cmd.CommandText = "INSERT INTO Games(Date, Opponent, Competition, Result) VALUES(@date, @opp, @comp, @res)";
             cmd.Parameters.AddWithValue("@date", game.Date.ToString("yyyy-MM-dd"));
             cmd.Parameters.AddWithValue("@opp", game.Opponent);
+            cmd.Parameters.AddWithValue("@comp", game.Competition);
             cmd.Parameters.AddWithValue("@res", game.Result);
             cmd.ExecuteNonQuery();
             cmd.CommandText = "SELECT last_insert_rowid()";
@@ -22,7 +23,7 @@ namespace GestaoEquipas.Data.DataAccess
         {
             using var conn = Database.GetConnection();
             var cmd = conn.CreateCommand();
-            cmd.CommandText = "SELECT Id, Date, Opponent, Result FROM Games";
+            cmd.CommandText = "SELECT Id, Date, Opponent, Competition, Result FROM Games ORDER BY Date DESC";
             using var reader = cmd.ExecuteReader();
             while (reader.Read())
             {
@@ -31,9 +32,25 @@ namespace GestaoEquipas.Data.DataAccess
                     Id = reader.GetInt32(0),
                     Date = System.DateTime.Parse(reader.GetString(1)),
                     Opponent = reader.GetString(2),
-                    Result = reader.GetString(3)
+                    Competition = reader.IsDBNull(3) ? "Liga" : reader.GetString(3),
+                    Result = reader.GetString(4)
                 };
             }
+        }
+
+        public void Delete(int gameId)
+        {
+            using var conn = Database.GetConnection();
+
+            var deleteStats = conn.CreateCommand();
+            deleteStats.CommandText = "DELETE FROM PerformanceStats WHERE GameId=@gid";
+            deleteStats.Parameters.AddWithValue("@gid", gameId);
+            deleteStats.ExecuteNonQuery();
+
+            var deleteGame = conn.CreateCommand();
+            deleteGame.CommandText = "DELETE FROM Games WHERE Id=@id";
+            deleteGame.Parameters.AddWithValue("@id", gameId);
+            deleteGame.ExecuteNonQuery();
         }
     }
 }

--- a/GestaoEquipas.Data/Models/Competition.cs
+++ b/GestaoEquipas.Data/Models/Competition.cs
@@ -1,0 +1,10 @@
+namespace GestaoEquipas.Data.Models
+{
+    public class Competition
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string Type { get; set; } = "Liga";
+        public string Season { get; set; } = string.Empty;
+    }
+}

--- a/GestaoEquipas.Data/Models/Game.cs
+++ b/GestaoEquipas.Data/Models/Game.cs
@@ -7,6 +7,21 @@ namespace GestaoEquipas.Data.Models
         public int Id { get; set; }
         public DateTime Date { get; set; }
         public string Opponent { get; set; } = string.Empty;
+        public string Competition { get; set; } = "Liga";
         public string Result { get; set; } = string.Empty; // e.g., "2-1"
+
+        public bool TryGetGoals(out int goalsFor, out int goalsAgainst)
+        {
+            goalsFor = 0;
+            goalsAgainst = 0;
+
+            var parts = Result.Split('-', StringSplitOptions.TrimEntries);
+            if (parts.Length != 2)
+            {
+                return false;
+            }
+
+            return int.TryParse(parts[0], out goalsFor) && int.TryParse(parts[1], out goalsAgainst);
+        }
     }
 }

--- a/GestaoEquipas.UI/Views/AttendanceWindow.xaml
+++ b/GestaoEquipas.UI/Views/AttendanceWindow.xaml
@@ -1,0 +1,30 @@
+<Window x:Class="GestaoEquipas.UI.Views.AttendanceWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Assiduidade" Height="520" Width="760">
+    <DockPanel Margin="10">
+        <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Margin="0 0 0 10">
+            <TextBlock Text="Sessão:" VerticalAlignment="Center" Margin="0 0 6 0"/>
+            <ComboBox Name="SessionCombo" Width="300" SelectionChanged="SessionCombo_SelectionChanged"/>
+            <Button Content="Atualizar" Margin="10 0 0 0" Click="Refresh_Click"/>
+        </StackPanel>
+
+        <TextBlock Text="Presenças por atleta" FontWeight="Bold" Margin="0 0 0 6"/>
+        <DataGrid Name="AttendanceGrid" AutoGenerateColumns="False" Height="180" Margin="0 0 0 10" IsReadOnly="True">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Atleta" Binding="{Binding PlayerName}" Width="*"/>
+                <DataGridTextColumn Header="Presença" Binding="{Binding PresenceText}" Width="100"/>
+            </DataGrid.Columns>
+        </DataGrid>
+
+        <TextBlock Text="Resumo acumulado" FontWeight="Bold" Margin="0 0 0 6"/>
+        <DataGrid Name="SummaryGrid" AutoGenerateColumns="False" IsReadOnly="True">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Atleta" Binding="{Binding PlayerName}" Width="*"/>
+                <DataGridTextColumn Header="Sessões" Binding="{Binding Sessions}" Width="80"/>
+                <DataGridTextColumn Header="Presentes" Binding="{Binding Presents}" Width="80"/>
+                <DataGridTextColumn Header="%" Binding="{Binding Percentage}" Width="80"/>
+            </DataGrid.Columns>
+        </DataGrid>
+    </DockPanel>
+</Window>

--- a/GestaoEquipas.UI/Views/AttendanceWindow.xaml
+++ b/GestaoEquipas.UI/Views/AttendanceWindow.xaml
@@ -1,7 +1,7 @@
 <Window x:Class="GestaoEquipas.UI.Views.AttendanceWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Assiduidade" Height="520" Width="760">
+        Title="FUTMAX | Assiduidade" Height="520" Width="760">
     <DockPanel Margin="10">
         <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Margin="0 0 0 10">
             <TextBlock Text="Sessão:" VerticalAlignment="Center" Margin="0 0 6 0"/>

--- a/GestaoEquipas.UI/Views/AttendanceWindow.xaml.cs
+++ b/GestaoEquipas.UI/Views/AttendanceWindow.xaml.cs
@@ -1,0 +1,153 @@
+using GestaoEquipas.Business.Services;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace GestaoEquipas.UI.Views
+{
+    public partial class AttendanceWindow : Window
+    {
+        private readonly TrainingService _trainingService = new TrainingService();
+        private readonly PlayerService _playerService = new PlayerService();
+        private readonly AttendanceService _attendanceService = new AttendanceService();
+
+        private readonly List<SessionOption> _sessions = new List<SessionOption>();
+
+        public AttendanceWindow()
+        {
+            InitializeComponent();
+            LoadSessions();
+            LoadSummary();
+        }
+
+        private void LoadSessions()
+        {
+            _sessions.Clear();
+            foreach (var session in _trainingService.GetSessions().OrderByDescending(s => s.Date))
+            {
+                _sessions.Add(new SessionOption
+                {
+                    Id = session.Id,
+                    Description = $"{session.Date:yyyy-MM-dd} - {session.Notes}"
+                });
+            }
+
+            SessionCombo.ItemsSource = _sessions;
+            SessionCombo.DisplayMemberPath = nameof(SessionOption.Description);
+            SessionCombo.SelectedValuePath = nameof(SessionOption.Id);
+
+            if (_sessions.Count > 0)
+            {
+                SessionCombo.SelectedIndex = 0;
+            }
+            else
+            {
+                AttendanceGrid.ItemsSource = null;
+            }
+        }
+
+        private void SessionCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            LoadSessionAttendance();
+        }
+
+        private void LoadSessionAttendance()
+        {
+            if (SessionCombo.SelectedItem is not SessionOption selected)
+            {
+                AttendanceGrid.ItemsSource = null;
+                return;
+            }
+
+            var players = _playerService.GetPlayers().ToDictionary(p => p.Id, p => p.Name);
+            var records = _attendanceService.GetBySession(selected.Id).ToList();
+
+            var rows = records
+                .Select(r => new AttendanceRow
+                {
+                    PlayerName = players.TryGetValue(r.PlayerId, out var name) ? name : $"Atleta #{r.PlayerId}",
+                    PresenceText = r.Present ? "Presente" : "Ausente"
+                })
+                .OrderBy(r => r.PlayerName)
+                .ToList();
+
+            AttendanceGrid.ItemsSource = rows;
+        }
+
+        private void LoadSummary()
+        {
+            var players = _playerService.GetPlayers().ToList();
+            var sessions = _trainingService.GetSessions().ToList();
+            var rows = new List<SummaryRow>();
+
+            foreach (var player in players)
+            {
+                int totalSessions = 0;
+                int presents = 0;
+
+                foreach (var session in sessions)
+                {
+                    var record = _attendanceService
+                        .GetBySession(session.Id)
+                        .FirstOrDefault(r => r.PlayerId == player.Id);
+
+                    if (record == null)
+                    {
+                        continue;
+                    }
+
+                    totalSessions += 1;
+                    if (record.Present)
+                    {
+                        presents += 1;
+                    }
+                }
+
+                double percentageValue = totalSessions == 0
+                    ? 0
+                    : Math.Round((double)presents / totalSessions * 100, 1);
+
+                rows.Add(new SummaryRow
+                {
+                    PlayerName = player.Name,
+                    Sessions = totalSessions,
+                    Presents = presents,
+                    Percentage = $"{percentageValue}%",
+                    PercentageValue = percentageValue
+                });
+            }
+
+            SummaryGrid.ItemsSource = rows.OrderByDescending(r => r.PercentageValue).ToList();
+        }
+
+        private void Refresh_Click(object sender, RoutedEventArgs e)
+        {
+            LoadSessions();
+            LoadSessionAttendance();
+            LoadSummary();
+        }
+
+        private class SessionOption
+        {
+            public int Id { get; set; }
+            public string Description { get; set; } = string.Empty;
+        }
+
+        private class AttendanceRow
+        {
+            public string PlayerName { get; set; } = string.Empty;
+            public string PresenceText { get; set; } = string.Empty;
+        }
+
+        private class SummaryRow
+        {
+            public string PlayerName { get; set; } = string.Empty;
+            public int Sessions { get; set; }
+            public int Presents { get; set; }
+            public string Percentage { get; set; } = string.Empty;
+            public double PercentageValue { get; set; }
+        }
+    }
+}

--- a/GestaoEquipas.UI/Views/CompetitionsWindow.xaml
+++ b/GestaoEquipas.UI/Views/CompetitionsWindow.xaml
@@ -1,7 +1,7 @@
 <Window x:Class="GestaoEquipas.UI.Views.CompetitionsWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Competições" Height="420" Width="620">
+        Title="FUTMAX | Competições" Height="420" Width="620">
     <DockPanel Margin="10">
         <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Margin="0 0 0 10">
             <TextBox Name="NameBox" Width="180" Margin="0 0 10 0" />

--- a/GestaoEquipas.UI/Views/CompetitionsWindow.xaml
+++ b/GestaoEquipas.UI/Views/CompetitionsWindow.xaml
@@ -1,0 +1,25 @@
+<Window x:Class="GestaoEquipas.UI.Views.CompetitionsWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Competições" Height="420" Width="620">
+    <DockPanel Margin="10">
+        <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Margin="0 0 0 10">
+            <TextBox Name="NameBox" Width="180" Margin="0 0 10 0" />
+            <ComboBox Name="TypeBox" Width="110" Margin="0 0 10 0">
+                <ComboBoxItem Content="Liga" IsSelected="True"/>
+                <ComboBoxItem Content="Taça"/>
+                <ComboBoxItem Content="Amigável"/>
+            </ComboBox>
+            <TextBox Name="SeasonBox" Width="120" Margin="0 0 10 0" Text="2025/2026"/>
+            <Button Content="Adicionar" Click="Add_Click"/>
+        </StackPanel>
+
+        <DataGrid Name="CompetitionsGrid" AutoGenerateColumns="False" IsReadOnly="True">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Nome" Binding="{Binding Name}" Width="*"/>
+                <DataGridTextColumn Header="Tipo" Binding="{Binding Type}" Width="110"/>
+                <DataGridTextColumn Header="Época" Binding="{Binding Season}" Width="120"/>
+            </DataGrid.Columns>
+        </DataGrid>
+    </DockPanel>
+</Window>

--- a/GestaoEquipas.UI/Views/CompetitionsWindow.xaml.cs
+++ b/GestaoEquipas.UI/Views/CompetitionsWindow.xaml.cs
@@ -1,0 +1,47 @@
+using GestaoEquipas.Business.Services;
+using GestaoEquipas.Data.Models;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace GestaoEquipas.UI.Views
+{
+    public partial class CompetitionsWindow : Window
+    {
+        private readonly CompetitionService _service = new CompetitionService();
+
+        public CompetitionsWindow()
+        {
+            InitializeComponent();
+            LoadCompetitions();
+        }
+
+        private void LoadCompetitions()
+        {
+            CompetitionsGrid.ItemsSource = _service.GetCompetitions().ToList();
+        }
+
+        private void Add_Click(object sender, RoutedEventArgs e)
+        {
+            var name = NameBox.Text.Trim();
+            var season = SeasonBox.Text.Trim();
+            var type = (TypeBox.SelectedItem as ComboBoxItem)?.Content?.ToString() ?? "Liga";
+
+            if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(season))
+            {
+                MessageBox.Show("Preencha Nome e Época.", "Validação", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            _service.AddCompetition(new Competition
+            {
+                Name = name,
+                Type = type,
+                Season = season
+            });
+
+            NameBox.Text = string.Empty;
+            LoadCompetitions();
+        }
+    }
+}

--- a/GestaoEquipas.UI/Views/GamesWindow.xaml
+++ b/GestaoEquipas.UI/Views/GamesWindow.xaml
@@ -1,18 +1,35 @@
 <Window x:Class="GestaoEquipas.UI.Views.GamesWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Jogos" Height="300" Width="400">
+        Title="Jogos" Height="520" Width="760">
     <DockPanel Margin="10">
         <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Margin="0 0 0 10">
             <DatePicker Name="DatePicker" Width="120" Margin="0 0 10 0"/>
             <TextBox Name="OpponentBox" Width="150" Margin="0 0 10 0" />
+            <ComboBox Name="CompetitionBox" Width="150" Margin="0 0 10 0"/>
             <TextBox Name="ResultBox" Width="60" Margin="0 0 10 0" />
             <Button Content="Adicionar" Click="Add_Click"/>
+            <Button Content="Remover Selecionado" Margin="8 0 0 0" Click="RemoveSelected_Click"/>
+        </StackPanel>
+        <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Margin="0 0 0 10">
+            <TextBlock Text="Filtro:" VerticalAlignment="Center" Margin="0 0 6 0"/>
+            <ComboBox Name="CompetitionFilterBox" Width="180" SelectionChanged="CompetitionFilterBox_SelectionChanged"/>
+            <TextBlock Name="SummaryText" Margin="20 0 0 0" VerticalAlignment="Center" FontWeight="SemiBold"/>
         </StackPanel>
         <DataGrid Name="PerformanceGrid" AutoGenerateColumns="False" Height="120" Margin="0 0 0 10">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Jogador" Binding="{Binding PlayerName}" IsReadOnly="True"/>
                 <DataGridTextColumn Header="Rating" Binding="{Binding Rating}"/>
+            </DataGrid.Columns>
+        </DataGrid>
+        <TextBlock Name="StandingsTitle" Text="Classificação" FontWeight="Bold" Margin="0 0 0 6"/>
+        <DataGrid Name="StandingsGrid" AutoGenerateColumns="False" Height="140" Margin="0 0 0 10" IsReadOnly="True">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="#" Binding="{Binding Position}" Width="40"/>
+                <DataGridTextColumn Header="Equipa" Binding="{Binding Team}" Width="*"/>
+                <DataGridTextColumn Header="J" Binding="{Binding Played}" Width="40"/>
+                <DataGridTextColumn Header="P" Binding="{Binding Points}" Width="40"/>
+                <DataGridTextColumn Header="DG" Binding="{Binding GoalDifference}" Width="45"/>
             </DataGrid.Columns>
         </DataGrid>
         <ListBox Name="GamesList" />

--- a/GestaoEquipas.UI/Views/GamesWindow.xaml
+++ b/GestaoEquipas.UI/Views/GamesWindow.xaml
@@ -1,7 +1,7 @@
 <Window x:Class="GestaoEquipas.UI.Views.GamesWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Jogos" Height="520" Width="760">
+        Title="FUTMAX | Jogos" Height="520" Width="760">
     <DockPanel Margin="10">
         <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Margin="0 0 0 10">
             <DatePicker Name="DatePicker" Width="120" Margin="0 0 10 0"/>

--- a/GestaoEquipas.UI/Views/GamesWindow.xaml.cs
+++ b/GestaoEquipas.UI/Views/GamesWindow.xaml.cs
@@ -2,7 +2,9 @@ using GestaoEquipas.Business.Services;
 using GestaoEquipas.Data.Models;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Windows;
+using System.Windows.Controls;
 
 namespace GestaoEquipas.UI.Views
 {
@@ -11,23 +13,93 @@ namespace GestaoEquipas.UI.Views
         private readonly GameService _service = new GameService();
         private readonly PlayerService _playerService = new PlayerService();
         private readonly PerformanceService _perfService = new PerformanceService();
+        private readonly CompetitionService _competitionService = new CompetitionService();
 
         private List<PerformanceRow> _rows = new List<PerformanceRow>();
+        private List<Game> _games = new List<Game>();
+        private List<GameListItem> _gameItems = new List<GameListItem>();
 
         public GamesWindow()
         {
             InitializeComponent();
             LoadGames();
             LoadPlayers();
+            LoadCompetitions();
+        }
+
+        private void LoadCompetitions()
+        {
+            var competitions = _competitionService.GetCompetitions().ToList();
+            CompetitionBox.ItemsSource = competitions;
+            CompetitionBox.DisplayMemberPath = nameof(Competition.Name);
+            CompetitionBox.SelectedValuePath = nameof(Competition.Name);
+            if (competitions.Count > 0)
+            {
+                CompetitionBox.SelectedIndex = 0;
+            }
+
+            CompetitionFilterBox.Items.Clear();
+            CompetitionFilterBox.Items.Add("Todas");
+            foreach (var comp in competitions.Select(c => c.Name).Distinct())
+            {
+                CompetitionFilterBox.Items.Add(comp);
+            }
+            CompetitionFilterBox.SelectedIndex = 0;
         }
 
         private void LoadGames()
         {
-            GamesList.Items.Clear();
-            foreach (var g in _service.GetGames())
+            _games = _service.GetGames().ToList();
+            ApplyGamesFilter();
+            ApplyStandings();
+        }
+
+        private void ApplyStandings()
+        {
+            var selectedFilter = CompetitionFilterBox.SelectedItem?.ToString();
+            var standingCompetition = string.IsNullOrWhiteSpace(selectedFilter) || selectedFilter == "Todas"
+                ? "Liga"
+                : selectedFilter;
+
+            StandingsTitle.Text = $"Classificação ({standingCompetition})";
+            StandingsGrid.ItemsSource = BuildStandings(_games, standingCompetition);
+        }
+
+        private void ApplyGamesFilter()
+        {
+            var games = _games;
+            var selectedFilter = CompetitionFilterBox.SelectedItem?.ToString();
+            if (!string.IsNullOrWhiteSpace(selectedFilter) && selectedFilter != "Todas")
             {
-                GamesList.Items.Add($"{g.Date:yyyy-MM-dd} vs {g.Opponent} - {g.Result}");
+                games = _games.Where(g => g.Competition == selectedFilter).ToList();
             }
+
+            GamesList.Items.Clear();
+            _gameItems.Clear();
+            foreach (var g in games)
+            {
+                var item = new GameListItem
+                {
+                    Id = g.Id,
+                    Display = $"[{g.Competition}] {g.Date:yyyy-MM-dd} vs {g.Opponent} - {g.Result}"
+                };
+                _gameItems.Add(item);
+                GamesList.Items.Add(item.Display);
+            }
+
+            var parsed = games.Where(g => g.TryGetGoals(out _, out _)).ToList();
+            int wins = 0;
+            int draws = 0;
+            int losses = 0;
+            foreach (var game in parsed)
+            {
+                game.TryGetGoals(out int gf, out int ga);
+                if (gf > ga) wins++;
+                else if (gf == ga) draws++;
+                else losses++;
+            }
+            SummaryText.Text = $"Jogos: {games.Count} | V:{wins} E:{draws} D:{losses}";
+            ApplyStandings();
         }
 
         private void LoadPlayers()
@@ -42,12 +114,33 @@ namespace GestaoEquipas.UI.Views
 
         private void Add_Click(object sender, RoutedEventArgs e)
         {
+            if (string.IsNullOrWhiteSpace(OpponentBox.Text))
+            {
+                MessageBox.Show("Indica o adversário.", "Validação", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            var result = ResultBox.Text.Trim();
+            if (string.IsNullOrWhiteSpace(result) || !result.Contains('-'))
+            {
+                MessageBox.Show("Resultado inválido. Usa formato X-Y.", "Validação", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
             var game = new Game
             {
                 Date = DatePicker.SelectedDate ?? DateTime.Now,
-                Opponent = OpponentBox.Text,
-                Result = ResultBox.Text
+                Opponent = OpponentBox.Text.Trim(),
+                Competition = CompetitionBox.SelectedValue?.ToString() ?? "Liga",
+                Result = result
             };
+
+            if (!game.TryGetGoals(out _, out _))
+            {
+                MessageBox.Show("Resultado inválido. Usa números inteiros no formato X-Y.", "Validação", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
             int gameId = _service.AddGame(game);
 
             var stats = new List<PerformanceStat>();
@@ -68,11 +161,107 @@ namespace GestaoEquipas.UI.Views
             LoadPlayers();
         }
 
+        private void CompetitionFilterBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            ApplyGamesFilter();
+        }
+
+        private void RemoveSelected_Click(object sender, RoutedEventArgs e)
+        {
+            int selectedIndex = GamesList.SelectedIndex;
+            if (selectedIndex < 0 || selectedIndex >= _gameItems.Count)
+            {
+                MessageBox.Show("Seleciona um jogo para remover.", "Validação", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            var selected = _gameItems[selectedIndex];
+            var confirm = MessageBox.Show($"Remover jogo?\n{selected.Display}", "Confirmar remoção", MessageBoxButton.YesNo, MessageBoxImage.Question);
+            if (confirm != MessageBoxResult.Yes)
+            {
+                return;
+            }
+
+            _service.DeleteGame(selected.Id);
+            LoadGames();
+        }
+
+        private static List<StandingRow> BuildStandings(List<Game> games, string competition)
+        {
+            var teamRows = new List<StandingRow>
+            {
+                new StandingRow { Team = "Minha Equipa" }
+            };
+
+            foreach (var game in games.Where(g => g.Competition == competition))
+            {
+                if (!game.TryGetGoals(out int gf, out int ga))
+                {
+                    continue;
+                }
+
+                var ourTeam = teamRows.First(r => r.Team == "Minha Equipa");
+                var opponent = teamRows.FirstOrDefault(r => r.Team == game.Opponent);
+                if (opponent == null)
+                {
+                    opponent = new StandingRow { Team = game.Opponent };
+                    teamRows.Add(opponent);
+                }
+
+                ApplyGame(ourTeam, gf, ga);
+                ApplyGame(opponent, ga, gf);
+            }
+
+            return teamRows
+                .OrderByDescending(r => r.Points)
+                .ThenByDescending(r => r.GoalDifference)
+                .ThenByDescending(r => r.GoalsFor)
+                .Select((row, index) =>
+                {
+                    row.Position = index + 1;
+                    return row;
+                })
+                .ToList();
+        }
+
+        private static void ApplyGame(StandingRow row, int goalsFor, int goalsAgainst)
+        {
+            row.Played += 1;
+            row.GoalsFor += goalsFor;
+            row.GoalsAgainst += goalsAgainst;
+
+            if (goalsFor > goalsAgainst)
+            {
+                row.Points += 3;
+            }
+            else if (goalsFor == goalsAgainst)
+            {
+                row.Points += 1;
+            }
+        }
+
         private class PerformanceRow
         {
             public int PlayerId { get; set; }
             public string PlayerName { get; set; } = string.Empty;
             public int Rating { get; set; }
+        }
+
+        private class StandingRow
+        {
+            public int Position { get; set; }
+            public string Team { get; set; } = string.Empty;
+            public int Played { get; set; }
+            public int Points { get; set; }
+            public int GoalsFor { get; set; }
+            public int GoalsAgainst { get; set; }
+            public int GoalDifference => GoalsFor - GoalsAgainst;
+        }
+
+        private class GameListItem
+        {
+            public int Id { get; set; }
+            public string Display { get; set; } = string.Empty;
         }
     }
 }

--- a/GestaoEquipas.UI/Views/MainWindow.xaml
+++ b/GestaoEquipas.UI/Views/MainWindow.xaml
@@ -1,7 +1,7 @@
 <Window x:Class="GestaoEquipas.UI.Views.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Gestão de Equipas" Height="350" Width="525">
+        Title="FUTMAX" Height="350" Width="525">
     <DockPanel>
         <Menu DockPanel.Dock="Top">
             <MenuItem Header="Jogadores" Click="Players_Click"/>
@@ -12,7 +12,7 @@
             <MenuItem Header="Tácticas" Click="Tactics_Click"/>
         </Menu>
         <Grid>
-            <TextBlock Text="Bem-vindo" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="20"/>
+            <TextBlock Text="Bem-vindo ao FUTMAX" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="20"/>
         </Grid>
     </DockPanel>
 </Window>

--- a/GestaoEquipas.UI/Views/MainWindow.xaml
+++ b/GestaoEquipas.UI/Views/MainWindow.xaml
@@ -7,6 +7,8 @@
             <MenuItem Header="Jogadores" Click="Players_Click"/>
             <MenuItem Header="Treinos" Click="Trainings_Click"/>
             <MenuItem Header="Jogos" Click="Games_Click"/>
+            <MenuItem Header="Competições" Click="Competitions_Click"/>
+            <MenuItem Header="Assiduidade" Click="Attendance_Click"/>
             <MenuItem Header="Tácticas" Click="Tactics_Click"/>
         </Menu>
         <Grid>

--- a/GestaoEquipas.UI/Views/MainWindow.xaml.cs
+++ b/GestaoEquipas.UI/Views/MainWindow.xaml.cs
@@ -32,5 +32,17 @@ namespace GestaoEquipas.UI.Views
             var win = new TacticsWindow();
             win.ShowDialog();
         }
+
+        private void Attendance_Click(object sender, RoutedEventArgs e)
+        {
+            var win = new AttendanceWindow();
+            win.ShowDialog();
+        }
+
+        private void Competitions_Click(object sender, RoutedEventArgs e)
+        {
+            var win = new CompetitionsWindow();
+            win.ShowDialog();
+        }
     }
 }

--- a/GestaoEquipas.UI/Views/PlayersWindow.xaml
+++ b/GestaoEquipas.UI/Views/PlayersWindow.xaml
@@ -1,7 +1,7 @@
 <Window x:Class="GestaoEquipas.UI.Views.PlayersWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Jogadores" Height="300" Width="400">
+        Title="FUTMAX | Jogadores" Height="300" Width="400">
     <DockPanel Margin="10">
         <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Margin="0 0 0 10">
             <TextBox Name="NameBox" Width="150" Margin="0 0 10 0" />

--- a/GestaoEquipas.UI/Views/TacticsWindow.xaml
+++ b/GestaoEquipas.UI/Views/TacticsWindow.xaml
@@ -1,7 +1,7 @@
 <Window x:Class="GestaoEquipas.UI.Views.TacticsWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Tácticas" Height="300" Width="400">
+        Title="FUTMAX | Tácticas" Height="300" Width="400">
     <Grid>
         <TextBlock Text="Editor tático em construção" HorizontalAlignment="Center" VerticalAlignment="Center"/>
     </Grid>

--- a/GestaoEquipas.UI/Views/TrainingsWindow.xaml
+++ b/GestaoEquipas.UI/Views/TrainingsWindow.xaml
@@ -1,7 +1,7 @@
 <Window x:Class="GestaoEquipas.UI.Views.TrainingsWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Treinos" Height="450" Width="450">
+        Title="FUTMAX | Treinos" Height="450" Width="450">
     <DockPanel Margin="10">
         <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Margin="0 0 0 10">
             <DatePicker Name="DatePicker" Width="120" Margin="0 0 10 0"/>

--- a/GestaoEquipas.UI/Views/TrainingsWindow.xaml
+++ b/GestaoEquipas.UI/Views/TrainingsWindow.xaml
@@ -16,11 +16,17 @@
         </DataGrid>
         <ListBox Name="SessionsList" Margin="0 0 0 10"/>
         <TextBlock Text="Exercícios:" FontWeight="Bold" Margin="0 5 0 2"/>
-        <ListBox Name="ExercisesList" SelectionMode="Extended" Height="80" Margin="0 0 0 10"/>
+        <StackPanel Orientation="Horizontal" Margin="0 0 0 4">
+            <CheckBox Name="IncludeArchivedCheck" Content="Mostrar arquivados" Checked="IncludeArchivedCheck_Changed" Unchecked="IncludeArchivedCheck_Changed"/>
+        </StackPanel>
+        <ListBox Name="ExercisesList" SelectionMode="Extended" Height="80" Margin="0 0 0 6" SelectionChanged="ExercisesList_SelectionChanged"/>
+        <TextBlock Name="ExercisePreviewText" Text="Seleciona um exercício para ver descrição." FontStyle="Italic" Margin="0 0 0 8"/>
         <StackPanel Orientation="Horizontal" Margin="0 0 0 10">
             <TextBox Name="ExerciseNameBox" Width="120" Margin="0 0 5 0" />
             <TextBox Name="ExerciseDescBox" Width="150" Margin="0 0 5 0" />
             <Button Content="Criar" Click="AddExercise_Click" />
+            <Button Content="Arquivar" Margin="8 0 0 0" Click="ArchiveExercise_Click" />
+            <Button Content="Reativar" Margin="8 0 0 0" Click="UnarchiveExercise_Click" />
         </StackPanel>
         <Button Content="Exportar PDF" Click="ExportPdf_Click" />
     </DockPanel>

--- a/GestaoEquipas.UI/Views/TrainingsWindow.xaml.cs
+++ b/GestaoEquipas.UI/Views/TrainingsWindow.xaml.cs
@@ -4,7 +4,9 @@ using System;
 using System.Collections.Generic;
 using PdfSharp.Drawing;
 using PdfSharp.Pdf;
+using System.Linq;
 using System.Windows;
+using System.Windows.Controls;
 
 namespace GestaoEquipas.UI.Views
 {
@@ -47,11 +49,12 @@ namespace GestaoEquipas.UI.Views
         private void LoadExercises()
         {
             ExercisesList.Items.Clear();
-            foreach (var ex in _exerciseService.GetExercises())
+            bool includeArchived = IncludeArchivedCheck?.IsChecked == true;
+            foreach (var ex in _exerciseService.GetExercises(includeArchived))
             {
                 ExercisesList.Items.Add(new System.Windows.Controls.ListBoxItem
                 {
-                    Content = ex.Name,
+                    Content = ex.Archived ? $"{ex.Name} [Arquivado]" : ex.Name,
                     Tag = ex
                 });
             }
@@ -86,15 +89,70 @@ namespace GestaoEquipas.UI.Views
 
         private void AddExercise_Click(object sender, RoutedEventArgs e)
         {
+            if (string.IsNullOrWhiteSpace(ExerciseNameBox.Text))
+            {
+                MessageBox.Show("Indica o nome do exercício.", "Validação", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
             var ex = new Exercise
             {
-                Name = ExerciseNameBox.Text,
-                Description = ExerciseDescBox.Text
+                Name = ExerciseNameBox.Text.Trim(),
+                Description = ExerciseDescBox.Text.Trim()
             };
             _exerciseService.AddExercise(ex);
             ExerciseNameBox.Text = "";
             ExerciseDescBox.Text = "";
             LoadExercises();
+        }
+
+        private void ArchiveExercise_Click(object sender, RoutedEventArgs e)
+        {
+            if (ExercisesList.SelectedItem is not ListBoxItem selected || selected.Tag is not Exercise exercise)
+            {
+                MessageBox.Show("Seleciona um exercício para arquivar.", "Validação", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            _exerciseService.ArchiveExercise(exercise.Id);
+            LoadExercises();
+            ExercisePreviewText.Text = "Exercício arquivado.";
+        }
+
+        private void UnarchiveExercise_Click(object sender, RoutedEventArgs e)
+        {
+            if (ExercisesList.SelectedItem is not ListBoxItem selected || selected.Tag is not Exercise exercise)
+            {
+                MessageBox.Show("Seleciona um exercício para reativar.", "Validação", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            _exerciseService.UnarchiveExercise(exercise.Id);
+            LoadExercises();
+            ExercisePreviewText.Text = "Exercício reativado.";
+        }
+
+        private void IncludeArchivedCheck_Changed(object sender, RoutedEventArgs e)
+        {
+            LoadExercises();
+        }
+
+        private void ExercisesList_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (ExercisesList.SelectedItem is ListBoxItem selected && selected.Tag is Exercise exercise)
+            {
+                ExercisePreviewText.Text = string.IsNullOrWhiteSpace(exercise.Description)
+                    ? $"{exercise.Name}: sem descrição."
+                    : $"{exercise.Name}: {exercise.Description}";
+            }
+            else if (ExercisesList.SelectedItems.Count > 1)
+            {
+                ExercisePreviewText.Text = $"{ExercisesList.SelectedItems.Count} exercícios selecionados.";
+            }
+            else
+            {
+                ExercisePreviewText.Text = "Seleciona um exercício para ver descrição.";
+            }
         }
 
         private void ExportPdf_Click(object sender, RoutedEventArgs e)
@@ -130,6 +188,11 @@ namespace GestaoEquipas.UI.Views
                 {
                     gfx.DrawString($"- {ex.Name}: {ex.Description}", font, XBrushes.Black, new XPoint(50, y));
                     y += 20;
+                }
+
+                if (!sheet.Exercises.Any())
+                {
+                    gfx.DrawString("Sem exercícios selecionados.", font, XBrushes.Black, new XPoint(50, y));
                 }
 
                 doc.Save(dlg.FileName);

--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ Este projeto é uma aplicação desktop desenvolvida em C# e WPF, inspirada no F
 - **Gestão de Jogos** – registar jogos e resultados.
 - **Editor Tático** – janela de demonstração para futuras funcionalidades.
 
+
+## Planeamento MVP
+
+Foi adicionada documentação de planeamento funcional e técnico da versão inicial em `docs/MVP_V1.md`.
+
 ## Licença
 
 Distribuído sob a [Licença MIT](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Gestão de Equipas
+# FUTMAX
 
-Este projeto é uma aplicação desktop desenvolvida em C# e WPF, inspirada no Football Manager. A aplicação fornece funcionalidades básicas de gestão de jogadores, treinos, jogos e táticas, armazenando os dados localmente em SQLite.
+O FUTMAX é uma aplicação desktop desenvolvida em C# e WPF, inspirada no Football Manager. A aplicação fornece funcionalidades básicas de gestão de jogadores, treinos, jogos e táticas, armazenando os dados localmente em SQLite.
 
 ## Pré-requisitos
 
@@ -20,7 +20,7 @@ Este projeto é uma aplicação desktop desenvolvida em C# e WPF, inspirada no F
 3. **Compilar:**
    - Selecione a configuração **Debug** e use `Build > Build Solution`.
 4. **Executar:**
-   - Pressione **F5** para iniciar a aplicação. Na primeira execução o arquivo `gestao_equipas.db` será criado automaticamente.
+   - Pressione **F5** para iniciar a aplicação. Na primeira execução o arquivo `futmax.db` será criado automaticamente.
 
 ## Estrutura do Projeto
 

--- a/docs/MVP_V1.md
+++ b/docs/MVP_V1.md
@@ -1,4 +1,4 @@
-# MVP v1 — Gestão de Equipas (Futebol Europeu)
+# MVP v1 — FUTMAX (Futebol Europeu)
 
 ## 1) Funcionalidades fechadas para a versão 1
 

--- a/docs/MVP_V1.md
+++ b/docs/MVP_V1.md
@@ -1,0 +1,181 @@
+# MVP v1 — Gestão de Equipas (Futebol Europeu)
+
+## 1) Funcionalidades fechadas para a versão 1
+
+### 1.1 Utilizadores e segurança
+- Login local com perfis: **Treinador Principal**, **Treinador Adjunto**, **Analista**, **Direção**.
+- Controlo de permissões por ecrã (leitura, edição, exportação).
+
+### 1.2 Atletas e plantel
+- Registar atleta com dados-base: nome, data de nascimento, nacionalidade, posição principal/secundária, pé preferido, número da camisola.
+- Estado desportivo: apto, lesionado, em recuperação, suspenso.
+- Gestão de plantel por época (equipa principal, sub-23, sub-19).
+
+### 1.3 Assiduidade
+- Registo de presenças em treino e jogo.
+- Marcação: presente, ausência justificada, ausência injustificada, atraso.
+- Relatório por atleta e por período.
+
+### 1.4 Jogos, competições e classificações
+- Calendário de jogos (amigáveis e oficiais).
+- Gestão de competições (liga, taça, fase de grupos, playoff).
+- Classificação automática por competição com critérios: pontos, diferença de golos e golos marcados.
+
+### 1.5 Treino e exercícios
+- Planeamento de sessões de treino com data, objetivos e intensidade.
+- Biblioteca de exercícios com etiquetas por objetivo (técnico/tático/físico/bola parada).
+- Criação de ficha de treino agregando exercícios.
+- Exportação de ficha para PDF e impressão.
+
+### 1.6 Táticas (v1)
+- Quadro tático 2D com campo e jogadores arrastáveis.
+- Definição de formação (ex.: 4-3-3, 4-4-2, 3-5-2).
+- Setas e zonas para instruções coletivas.
+- Gravar e carregar modelos táticos.
+
+## 2) Modelo de dados (base de dados)
+
+> Stack atual: SQLite + camadas Data/Business/UI em C# (WPF).
+
+### 2.1 Entidades nucleares
+- `Player`
+- `TrainingSession`
+- `Exercise`
+- `TrainingSheet`
+- `AttendanceRecord`
+- `Game`
+- `Competition`
+- `StandingRow`
+- `TacticBoard`
+- `TacticItem`
+
+### 2.2 Esquema SQL proposto (MVP)
+
+```sql
+CREATE TABLE IF NOT EXISTS Player (
+  Id INTEGER PRIMARY KEY AUTOINCREMENT,
+  FullName TEXT NOT NULL,
+  BirthDate TEXT,
+  Nationality TEXT,
+  MainPosition TEXT,
+  SecondaryPosition TEXT,
+  PreferredFoot TEXT,
+  ShirtNumber INTEGER,
+  Squad TEXT,
+  Status TEXT DEFAULT 'Apto'
+);
+
+CREATE TABLE IF NOT EXISTS Competition (
+  Id INTEGER PRIMARY KEY AUTOINCREMENT,
+  Name TEXT NOT NULL,
+  Type TEXT NOT NULL, -- Liga, Taca, Grupos, Playoff
+  Season TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS Game (
+  Id INTEGER PRIMARY KEY AUTOINCREMENT,
+  GameDate TEXT NOT NULL,
+  Opponent TEXT NOT NULL,
+  CompetitionId INTEGER,
+  IsHome INTEGER NOT NULL DEFAULT 1,
+  GoalsFor INTEGER DEFAULT 0,
+  GoalsAgainst INTEGER DEFAULT 0,
+  Round TEXT,
+  FOREIGN KEY (CompetitionId) REFERENCES Competition(Id)
+);
+
+CREATE TABLE IF NOT EXISTS TrainingSession (
+  Id INTEGER PRIMARY KEY AUTOINCREMENT,
+  SessionDate TEXT NOT NULL,
+  Objective TEXT,
+  Intensity TEXT,
+  Notes TEXT
+);
+
+CREATE TABLE IF NOT EXISTS Exercise (
+  Id INTEGER PRIMARY KEY AUTOINCREMENT,
+  Title TEXT NOT NULL,
+  Category TEXT,
+  DurationMinutes INTEGER,
+  Material TEXT,
+  Description TEXT
+);
+
+CREATE TABLE IF NOT EXISTS TrainingSheet (
+  Id INTEGER PRIMARY KEY AUTOINCREMENT,
+  SessionId INTEGER NOT NULL,
+  Title TEXT NOT NULL,
+  PdfPath TEXT,
+  CreatedAt TEXT NOT NULL,
+  FOREIGN KEY (SessionId) REFERENCES TrainingSession(Id)
+);
+
+CREATE TABLE IF NOT EXISTS TrainingSheetExercise (
+  Id INTEGER PRIMARY KEY AUTOINCREMENT,
+  TrainingSheetId INTEGER NOT NULL,
+  ExerciseId INTEGER NOT NULL,
+  SequenceOrder INTEGER NOT NULL,
+  FOREIGN KEY (TrainingSheetId) REFERENCES TrainingSheet(Id),
+  FOREIGN KEY (ExerciseId) REFERENCES Exercise(Id)
+);
+
+CREATE TABLE IF NOT EXISTS AttendanceRecord (
+  Id INTEGER PRIMARY KEY AUTOINCREMENT,
+  PlayerId INTEGER NOT NULL,
+  ContextType TEXT NOT NULL, -- Training/Game
+  ContextId INTEGER NOT NULL,
+  Status TEXT NOT NULL, -- Presente/Justificada/Injustificada/Atraso
+  Notes TEXT,
+  FOREIGN KEY (PlayerId) REFERENCES Player(Id)
+);
+
+CREATE TABLE IF NOT EXISTS TacticBoard (
+  Id INTEGER PRIMARY KEY AUTOINCREMENT,
+  Name TEXT NOT NULL,
+  Formation TEXT,
+  CreatedAt TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS TacticItem (
+  Id INTEGER PRIMARY KEY AUTOINCREMENT,
+  BoardId INTEGER NOT NULL,
+  ItemType TEXT NOT NULL, -- Player, Arrow, Zone
+  X REAL NOT NULL,
+  Y REAL NOT NULL,
+  Label TEXT,
+  MetaJson TEXT,
+  FOREIGN KEY (BoardId) REFERENCES TacticBoard(Id)
+);
+```
+
+## 3) Estrutura do projeto (alinhada com o repositório)
+
+- `GestaoEquipas.Data`
+  - `Models/` (entidades)
+  - `DataAccess/` (repositórios e inicialização SQLite)
+- `GestaoEquipas.Business`
+  - `Services/` (regras de negócio por domínio)
+- `GestaoEquipas.UI`
+  - `Views/` (janelas WPF)
+
+## 4) Primeiras páginas/ecrãs a implementar no MVP
+
+1. **Dashboard**
+   - Resumo semanal: próximos jogos, treinos, atletas indisponíveis.
+2. **Atletas**
+   - Lista + formulário de registo/edição.
+3. **Treinos**
+   - Agenda de sessões + criação de ficha com exercícios.
+4. **Jogos e Competições**
+   - Calendário, detalhe de jogo, classificação.
+5. **Assiduidade**
+   - Grelha por sessão/jogo com marcação rápida.
+6. **Táticas (Editor v1)**
+   - Campo, formação base, objetos gráficos, gravação de modelo.
+
+## 5) Critérios de aceitação do MVP
+- CRUD funcional para Atletas, Treinos, Exercícios e Jogos.
+- Classificação automática para competições de liga.
+- Exportação de ficha de treino para PDF.
+- Editor tático com gravação/carregamento de pelo menos 1 modelo.
+- Dados persistidos em SQLite com migração inicial automática.


### PR DESCRIPTION
### Motivation
- Introduce formal support for competitions and per-competition game tracking to enable classification/standings and filtering of games.
- Provide an attendance overview UI to review session presences and aggregated summaries.
- Improve training workflow with exercise archiving, preview and ability to include archived items in exports.
- Persist schema changes to support the above features and seed initial competitions on first run.

### Description
- Added `Competition` model, `CompetitionRepository`, and `CompetitionService`, and a `CompetitionsWindow` UI to create and list competitions.
- Extended `Game` model with `Competition` and `TryGetGoals`, updated `GameRepository` to store/load the `Competition` column and added `Delete` to remove a game and its `PerformanceStats`, and added `DeleteGame` to `GameService`.
- Updated `Database` initialization to create `Competitions` table, ALTER `Games` to add `Competition` with a migration guard, and seeded default competitions for `2025/2026`.
- Enhanced `GamesWindow` with competition selection/filtering, game removal, match summary (wins/draws/losses), and automatic standings builder; updated `MainWindow` to expose competitions and attendance windows.
- Added `AttendanceWindow` UI and backing code to view per-session attendance and aggregated player summaries using `TrainingService`, `AttendanceService`, and `PlayerService`.
- Extended `TrainingsWindow` to support exercise archiving/unarchiving, include archived toggle, exercise preview, validation, and small PDF export improvements; updated exercise listing to show archived state.
- Small README update and added `docs/MVP_V1.md` containing MVP planning and data model proposals.

### Testing
- No automated tests were executed as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f742f02b6c83299dfdd35ba95cb8c6)